### PR TITLE
Conductrfy project

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,7 @@
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
 // Needed for importing the project into Eclipse
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-lagom-bundle" % "1.0.2")
+
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.4.2")


### PR DESCRIPTION
Add settings to run the Lagom project on ConductR. In particular it is necessary yo:
- Add `sbt-lagom-bundle` plugin to the `plugins.sbt`
- Add `sbt-conductr-sandbox` plugin to the `plugins.sbt`
- Set `SandboxKeys.imageVersion` in the `build.sbt`